### PR TITLE
Add service and region suffix to pool names

### DIFF
--- a/terraform/cognito.tf
+++ b/terraform/cognito.tf
@@ -1,6 +1,5 @@
 resource "aws_cognito_user_pool" "cognito_user_pool" {
-  // TODO add -use1 suffix
-  name = "${var.environment_name}-user-pool"
+  name = "${var.environment_name}-${var.service_name}-users-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
 
   auto_verified_attributes = ["email"]
   mfa_configuration        = "OPTIONAL"
@@ -30,21 +29,13 @@ resource "aws_cognito_user_pool" "cognito_user_pool" {
   }
 }
 
-resource "aws_cognito_user_group" "participants_cognito_user_group" {
-  name         = "${var.environment_name}-participants"
-  description  = "Cognito user group to distinguish participant users"
-  user_pool_id = aws_cognito_user_pool.cognito_user_pool.id
-}
-
-// TODO: do we need hosted domains?
 resource "aws_cognito_user_pool_domain" "cognito_user_pool_domain" {
-  domain       = "${var.environment_name}-pennsieve-users-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+  domain       = aws_cognito_user_pool.cognito_user_pool.name
   user_pool_id = aws_cognito_user_pool.cognito_user_pool.id
 }
 
 resource "aws_cognito_user_pool_client" "cognito_user_pool_client" {
-  // TODO add -use1 suffix
-  name                         = "${var.environment_name}-app-client"
+  name                         = "${var.environment_name}-${var.service_name}-users-app-client-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
   user_pool_id                 = aws_cognito_user_pool.cognito_user_pool.id
   supported_identity_providers = ["COGNITO"]
   explicit_auth_flows          = ["ADMIN_NO_SRP_AUTH"]
@@ -59,8 +50,7 @@ resource "aws_cognito_user_pool_ui_customization" "cognito_ui_customization" {
 }
 
 resource "aws_cognito_user_pool" "cognito_token_pool" {
-  // TODO add -use1 suffix
-  name = "${var.environment_name}-token-pool"
+  name = "${var.environment_name}-${var.service_name}-client-tokens-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
 
   mfa_configuration = "OFF"
 
@@ -85,20 +75,8 @@ resource "aws_cognito_user_pool" "cognito_token_pool" {
   }
 }
 
-resource "aws_cognito_user_group" "tokens_cognito_user_group" {
-  name         = "${var.environment_name}-tokens"
-  user_pool_id = aws_cognito_user_pool.cognito_token_pool.id
-}
-
-// TODO: do we need hosted domains
-resource "aws_cognito_user_pool_domain" "cognito_token_pool_domain" {
-  domain       = "${var.environment_name}-pennsieve-tokens-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
-  user_pool_id = aws_cognito_user_pool.cognito_token_pool.id
-}
-
 resource "aws_cognito_user_pool_client" "cognito_token_pool_client" {
-  // TODO add -use1 suffix
-  name                         = "${var.environment_name}-app-client"
+  name                         = "${var.environment_name}-client-tokens-app-client-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
   user_pool_id                 = aws_cognito_user_pool.cognito_token_pool.id
   supported_identity_providers = ["COGNITO"]
   explicit_auth_flows          = ["USER_PASSWORD_AUTH"]


### PR DESCRIPTION
```
Terraform will perform the following actions:

  # aws_cognito_user_group.participants_cognito_user_group will be destroyed
  - resource "aws_cognito_user_group" "participants_cognito_user_group" {
      - description  = "Cognito user group to distinguish participant users" -> null
      - id           = "us-east-1_jOTRYd628/dev-participants" -> null
      - name         = "dev-participants" -> null
      - precedence   = 0 -> null
      - user_pool_id = "us-east-1_jOTRYd628" -> null
    }

  # aws_cognito_user_group.tokens_cognito_user_group will be destroyed
  - resource "aws_cognito_user_group" "tokens_cognito_user_group" {
      - id           = "us-east-1_24NMNZenM/dev-tokens" -> null
      - name         = "dev-tokens" -> null
      - precedence   = 0 -> null
      - user_pool_id = "us-east-1_24NMNZenM" -> null
    }

  # aws_cognito_user_pool.cognito_token_pool will be destroyed
  - resource "aws_cognito_user_pool" "cognito_token_pool" {
      - arn                      = "arn:aws:cognito-idp:us-east-1:941165240011:userpool/us-east-1_24NMNZenM" -> null
      - auto_verified_attributes = [] -> null
      - creation_date            = "2021-03-18T20:36:58Z" -> null
      - endpoint                 = "cognito-idp.us-east-1.amazonaws.com/us-east-1_24NMNZenM" -> null
      - id                       = "us-east-1_24NMNZenM" -> null
      - last_modified_date       = "2021-03-24T18:32:18Z" -> null
      - mfa_configuration        = "OFF" -> null
      - name                     = "dev-token-pool" -> null
      - tags                     = {} -> null

      - account_recovery_setting {
        }

      - admin_create_user_config {
          - allow_admin_create_user_only = true -> null
        }

      - device_configuration {
          - challenge_required_on_new_device      = false -> null
          - device_only_remembered_on_user_prompt = true -> null
        }

      - email_configuration {
          - email_sending_account = "COGNITO_DEFAULT" -> null
        }

      - password_policy {
          - minimum_length                   = 36 -> null
          - require_lowercase                = false -> null
          - require_numbers                  = false -> null
          - require_symbols                  = false -> null
          - require_uppercase                = false -> null
          - temporary_password_validity_days = 7 -> null
        }

      - username_configuration {
          - case_sensitive = false -> null
        }

      - verification_message_template {
          - default_email_option = "CONFIRM_WITH_CODE" -> null
        }
    }

  # aws_cognito_user_pool.cognito_user_pool will be destroyed
  - resource "aws_cognito_user_pool" "cognito_user_pool" {
      - arn                      = "arn:aws:cognito-idp:us-east-1:941165240011:userpool/us-east-1_jOTRYd628" -> null
      - auto_verified_attributes = [] -> null
      - creation_date            = "2021-03-03T16:19:51Z" -> null
      - endpoint                 = "cognito-idp.us-east-1.amazonaws.com/us-east-1_jOTRYd628" -> null
      - id                       = "us-east-1_jOTRYd628" -> null
      - last_modified_date       = "2021-03-29T15:17:54Z" -> null
      - mfa_configuration        = "OPTIONAL" -> null
      - name                     = "dev-user-pool" -> null
      - tags                     = {} -> null
      - username_attributes      = [
          - "email",
        ] -> null

      - account_recovery_setting {
          - recovery_mechanism {
              - name     = "verified_email" -> null
              - priority = 1 -> null
            }
        }

      - admin_create_user_config {
          - allow_admin_create_user_only = false -> null
        }

      - email_configuration {
          - email_sending_account = "COGNITO_DEFAULT" -> null
        }

      - lambda_config {
          - define_auth_challenge = "arn:aws:lambda:us-east-1:941165240011:function:test-cognito-lambda-trigger" -> null
          - pre_authentication    = "arn:aws:lambda:us-east-1:941165240011:function:test-cognito-lambda-trigger" -> null
          - pre_token_generation  = "arn:aws:lambda:us-east-1:941165240011:function:test-cognito-lambda-trigger" -> null
        }

      - password_policy {
          - minimum_length                   = 8 -> null
          - require_lowercase                = true -> null
          - require_numbers                  = true -> null
          - require_symbols                  = true -> null
          - require_uppercase                = true -> null
          - temporary_password_validity_days = 7 -> null
        }

      - schema {
          - attribute_data_type      = "String" -> null
          - developer_only_attribute = false -> null
          - mutable                  = true -> null
          - name                     = "testOrganizationId" -> null
          - required                 = false -> null

          - string_attribute_constraints {
              - max_length = "256" -> null
              - min_length = "1" -> null
            }
        }

      - software_token_mfa_configuration {
          - enabled = true -> null
        }

      - username_configuration {
          - case_sensitive = false -> null
        }

      - verification_message_template {
          - default_email_option = "CONFIRM_WITH_CODE" -> null
        }
    }

  # aws_cognito_user_pool_client.cognito_token_pool_client will be destroyed
  - resource "aws_cognito_user_pool_client" "cognito_token_pool_client" {
      - access_token_validity                = 0 -> null
      - allowed_oauth_flows                  = [] -> null
      - allowed_oauth_flows_user_pool_client = false -> null
      - allowed_oauth_scopes                 = [] -> null
      - callback_urls                        = [] -> null
      - explicit_auth_flows                  = [
          - "USER_PASSWORD_AUTH",
        ] -> null
      - id                                   = "4u5rlj8md7n5gau493meiqnh68" -> null
      - id_token_validity                    = 0 -> null
      - logout_urls                          = [] -> null
      - name                                 = "dev-app-client" -> null
      - read_attributes                      = [] -> null
      - refresh_token_validity               = 30 -> null
      - supported_identity_providers         = [
          - "COGNITO",
        ] -> null
      - user_pool_id                         = "us-east-1_24NMNZenM" -> null
      - write_attributes                     = [] -> null
    }

  # aws_cognito_user_pool_client.cognito_user_pool_client will be destroyed
  - resource "aws_cognito_user_pool_client" "cognito_user_pool_client" {
      - access_token_validity                = 60 -> null
      - allowed_oauth_flows                  = [] -> null
      - allowed_oauth_flows_user_pool_client = false -> null
      - allowed_oauth_scopes                 = [] -> null
      - callback_urls                        = [] -> null
      - explicit_auth_flows                  = [
          - "ALLOW_ADMIN_USER_PASSWORD_AUTH",
          - "ALLOW_CUSTOM_AUTH",
          - "ALLOW_REFRESH_TOKEN_AUTH",
          - "ALLOW_USER_PASSWORD_AUTH",
          - "ALLOW_USER_SRP_AUTH",
        ] -> null
      - id                                   = "5hbrbocmmrjb8epa9as68gnd1e" -> null
      - id_token_validity                    = 60 -> null
      - logout_urls                          = [] -> null
      - name                                 = "dev-app-client" -> null
      - prevent_user_existence_errors        = "LEGACY" -> null
      - read_attributes                      = [
          - "custom:testOrganizationId",
          - "email",
        ] -> null
      - refresh_token_validity               = 30 -> null
      - supported_identity_providers         = [
          - "COGNITO",
        ] -> null
      - user_pool_id                         = "us-east-1_jOTRYd628" -> null
      - write_attributes                     = [
          - "email",
        ] -> null

      - token_validity_units {
          - access_token  = "minutes" -> null
          - id_token      = "minutes" -> null
          - refresh_token = "days" -> null
        }
    }

  # aws_cognito_user_pool_domain.cognito_token_pool_domain will be destroyed
  - resource "aws_cognito_user_pool_domain" "cognito_token_pool_domain" {
      - aws_account_id              = "941165240011" -> null
      - cloudfront_distribution_arn = "d3oia8etllorh5.cloudfront.net" -> null
      - domain                      = "dev-pennsieve-tokens-use1" -> null
      - id                          = "dev-pennsieve-tokens-use1" -> null
      - s3_bucket                   = "aws-cognito-prod-iad-assets" -> null
      - user_pool_id                = "us-east-1_24NMNZenM" -> null
      - version                     = "20210324120000" -> null
    }

  # aws_cognito_user_pool_domain.cognito_user_pool_domain will be destroyed
  - resource "aws_cognito_user_pool_domain" "cognito_user_pool_domain" {
      - aws_account_id              = "941165240011" -> null
      - cloudfront_distribution_arn = "d3oia8etllorh5.cloudfront.net" -> null
      - domain                      = "dev-pennsieve-users-use1" -> null
      - id                          = "dev-pennsieve-users-use1" -> null
      - s3_bucket                   = "aws-cognito-prod-iad-assets" -> null
      - user_pool_id                = "us-east-1_jOTRYd628" -> null
      - version                     = "20210324120001" -> null
    }

  # aws_cognito_user_pool_ui_customization.cognito_ui_customization will be destroyed
  - resource "aws_cognito_user_pool_ui_customization" "cognito_ui_customization" {
      - client_id          = "5hbrbocmmrjb8epa9as68gnd1e" -> null
      - creation_date      = "0001-01-01T00:00:00Z" -> null
      - css                = <<-EOT
            .background-customizable {
            	background-color: #fbfbfd;
            }

            .banner-customizable {
            	padding: 48px 0 32px 0;
            	background-color: #ffffff;
            }

            .inputField-customizable {
            	width: 100%;
            	height: 40px;
            	color: #000;
            	background-color: #f1f1f3;
            	border: 1px solid #d6d7de;
            }

            .inputField-customizable:focus {
            	border-color: #2052e3;
            	outline: 0;
            }

            .label-customizable {
            	font-weight: 400;
            }

            .logo-customizable {
            	max-width: 60%;
            	max-height: 30%;
            }

            .redirect-customizable {
            	text-align: center;
            	color: #2052e3;
            	margin-top: 16px;
            	display: block;
            }

            .submitButton-customizable {
            	font-size: 14px;
            	font-weight: 500;
            	margin: 32px 0 0;
            	height: 48px;
            	width: 100%;
            	color: #fff;
            	background-color: #000000;
            }

            .submitButton-customizable:hover {
            	color: #fff;
            	background-color: #000000;
            }

            .textDescription-customizable {
            	padding-top: 24px;
            	padding-bottom: 32px;
            	display: block;
            	font-size: 16px;
            }
        EOT -> null
      - css_version        = "20210303162048" -> null
      - id                 = "us-east-1_jOTRYd628,5hbrbocmmrjb8epa9as68gnd1e" -> null
      - last_modified_date = "0001-01-01T00:00:00Z" -> null
      - user_pool_id       = "us-east-1_jOTRYd628" -> null
    }

  # module.service_module.aws_cognito_user_pool.cognito_token_pool will be created
  + resource "aws_cognito_user_pool" "cognito_token_pool" {
      + arn                        = (known after apply)
      + creation_date              = (known after apply)
      + email_verification_message = (known after apply)
      + email_verification_subject = (known after apply)
      + endpoint                   = (known after apply)
      + id                         = (known after apply)
      + last_modified_date         = (known after apply)
      + mfa_configuration          = "OFF"
      + name                       = "dev-authentication-service-client-tokens-use1"
      + sms_verification_message   = (known after apply)

      + admin_create_user_config {
          + allow_admin_create_user_only = true
        }

      + device_configuration {
          + device_only_remembered_on_user_prompt = true
        }

      + lambda_config {
          + create_auth_challenge          = (known after apply)
          + custom_message                 = (known after apply)
          + define_auth_challenge          = (known after apply)
          + post_authentication            = (known after apply)
          + post_confirmation              = (known after apply)
          + pre_authentication             = (known after apply)
          + pre_sign_up                    = (known after apply)
          + pre_token_generation           = (known after apply)
          + user_migration                 = (known after apply)
          + verify_auth_challenge_response = (known after apply)
        }

      + password_policy {
          + minimum_length    = 36
          + require_lowercase = false
          + require_numbers   = false
          + require_symbols   = false
          + require_uppercase = false
        }

      + sms_configuration {
          + external_id    = (known after apply)
          + sns_caller_arn = (known after apply)
        }

      + username_configuration {
          + case_sensitive = false
        }

      + verification_message_template {
          + default_email_option  = (known after apply)
          + email_message         = (known after apply)
          + email_message_by_link = (known after apply)
          + email_subject         = (known after apply)
          + email_subject_by_link = (known after apply)
          + sms_message           = (known after apply)
        }
    }

  # module.service_module.aws_cognito_user_pool.cognito_user_pool will be created
  + resource "aws_cognito_user_pool" "cognito_user_pool" {
      + arn                        = (known after apply)
      + auto_verified_attributes   = [
          + "email",
        ]
      + creation_date              = (known after apply)
      + email_verification_message = (known after apply)
      + email_verification_subject = (known after apply)
      + endpoint                   = (known after apply)
      + id                         = (known after apply)
      + last_modified_date         = (known after apply)
      + mfa_configuration          = "OPTIONAL"
      + name                       = "dev-authentication-service-users-use1"
      + sms_verification_message   = (known after apply)
      + username_attributes        = [
          + "email",
        ]

      + account_recovery_setting {
          + recovery_mechanism {
              + name     = "verified_email"
              + priority = 1
            }
        }

      + admin_create_user_config {
          + allow_admin_create_user_only = true
        }

      + device_configuration {
          + device_only_remembered_on_user_prompt = true
        }

      + lambda_config {
          + create_auth_challenge          = (known after apply)
          + custom_message                 = (known after apply)
          + define_auth_challenge          = (known after apply)
          + post_authentication            = (known after apply)
          + post_confirmation              = (known after apply)
          + pre_authentication             = (known after apply)
          + pre_sign_up                    = (known after apply)
          + pre_token_generation           = (known after apply)
          + user_migration                 = (known after apply)
          + verify_auth_challenge_response = (known after apply)
        }

      + password_policy {
          + minimum_length                   = (known after apply)
          + require_lowercase                = (known after apply)
          + require_numbers                  = (known after apply)
          + require_symbols                  = (known after apply)
          + require_uppercase                = (known after apply)
          + temporary_password_validity_days = (known after apply)
        }

      + sms_configuration {
          + external_id    = (known after apply)
          + sns_caller_arn = (known after apply)
        }

      + software_token_mfa_configuration {
          + enabled = true
        }

      + username_configuration {
          + case_sensitive = false
        }

      + verification_message_template {
          + default_email_option  = (known after apply)
          + email_message         = (known after apply)
          + email_message_by_link = (known after apply)
          + email_subject         = (known after apply)
          + email_subject_by_link = (known after apply)
          + sms_message           = (known after apply)
        }
    }

  # module.service_module.aws_cognito_user_pool_client.cognito_token_pool_client will be created
  + resource "aws_cognito_user_pool_client" "cognito_token_pool_client" {
      + client_secret                 = (sensitive value)
      + explicit_auth_flows           = [
          + "USER_PASSWORD_AUTH",
        ]
      + id                            = (known after apply)
      + name                          = "dev-client-tokens-app-client-use1"
      + prevent_user_existence_errors = (known after apply)
      + refresh_token_validity        = 30
      + supported_identity_providers  = [
          + "COGNITO",
        ]
      + user_pool_id                  = (known after apply)
    }

  # module.service_module.aws_cognito_user_pool_client.cognito_user_pool_client will be created
  + resource "aws_cognito_user_pool_client" "cognito_user_pool_client" {
      + client_secret                 = (sensitive value)
      + explicit_auth_flows           = [
          + "ADMIN_NO_SRP_AUTH",
        ]
      + id                            = (known after apply)
      + name                          = "dev-authentication-service-users-app-client-use1"
      + prevent_user_existence_errors = (known after apply)
      + read_attributes               = [
          + "email",
        ]
      + refresh_token_validity        = 30
      + supported_identity_providers  = [
          + "COGNITO",
        ]
      + user_pool_id                  = (known after apply)
      + write_attributes              = [
          + "email",
        ]
    }

  # module.service_module.aws_cognito_user_pool_domain.cognito_user_pool_domain will be created
  + resource "aws_cognito_user_pool_domain" "cognito_user_pool_domain" {
      + aws_account_id              = (known after apply)
      + cloudfront_distribution_arn = (known after apply)
      + domain                      = "dev-authentication-service-users-use1"
      + id                          = (known after apply)
      + s3_bucket                   = (known after apply)
      + user_pool_id                = (known after apply)
      + version                     = (known after apply)
    }

  # module.service_module.aws_cognito_user_pool_ui_customization.cognito_ui_customization will be created
  + resource "aws_cognito_user_pool_ui_customization" "cognito_ui_customization" {
      + client_id          = (known after apply)
      + creation_date      = (known after apply)
      + css                = <<-EOT
            .background-customizable {
            	background-color: #fbfbfd;
            }

            .banner-customizable {
            	padding: 48px 0 32px 0;
            	background-color: #ffffff;
            }

            .inputField-customizable {
            	width: 100%;
            	height: 40px;
            	color: #000;
            	background-color: #f1f1f3;
            	border: 1px solid #d6d7de;
            }

            .inputField-customizable:focus {
            	border-color: #2052e3;
            	outline: 0;
            }

            .label-customizable {
            	font-weight: 400;
            }

            .logo-customizable {
            	max-width: 60%;
            	max-height: 30%;
            }

            .redirect-customizable {
            	text-align: center;
            	color: #2052e3;
            	margin-top: 16px;
            	display: block;
            }

            .submitButton-customizable {
            	font-size: 14px;
            	font-weight: 500;
            	margin: 32px 0 0;
            	height: 48px;
            	width: 100%;
            	color: #fff;
            	background-color: #000000;
            }

            .submitButton-customizable:hover {
            	color: #fff;
            	background-color: #000000;
            }

            .textDescription-customizable {
            	padding-top: 24px;
            	padding-bottom: 32px;
            	display: block;
            	font-size: 16px;
            }
        EOT
      + css_version        = (known after apply)
      + id                 = (known after apply)
      + image_url          = (known after apply)
      + last_modified_date = (known after apply)
      + user_pool_id       = (known after apply)
    }

Plan: 6 to add, 0 to change, 9 to destroy.

Changes to Outputs:
  ~ token_pool_arn       = "arn:aws:cognito-idp:us-east-1:941165240011:userpool/us-east-1_24NMNZenM" -> (known after apply)
  ~ token_pool_client_id = "4u5rlj8md7n5gau493meiqnh68" -> (known after apply)
  ~ token_pool_id        = "us-east-1_24NMNZenM" -> (known after apply)
  ~ user_pool_arn        = "arn:aws:cognito-idp:us-east-1:941165240011:userpool/us-east-1_jOTRYd628" -> (known after apply)
  ~ user_pool_client_id  = "5hbrbocmmrjb8epa9as68gnd1e" -> (known after apply)
  ~ user_pool_id         = "us-east-1_jOTRYd628" -> (known after apply)

------------------------------------------------------------------------
```