### PR TITLE
Remove $service_name from resources

### DIFF
--- a/terraform/cognito.tf
+++ b/terraform/cognito.tf
@@ -1,5 +1,5 @@
 resource "aws_cognito_user_pool" "cognito_user_pool" {
-  name = "${var.environment_name}-${var.service_name}-users-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+  name = "${var.environment_name}-users-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
 
   auto_verified_attributes = ["email"]
   mfa_configuration        = "OPTIONAL"
@@ -35,7 +35,7 @@ resource "aws_cognito_user_pool_domain" "cognito_user_pool_domain" {
 }
 
 resource "aws_cognito_user_pool_client" "cognito_user_pool_client" {
-  name                         = "${var.environment_name}-${var.service_name}-users-app-client-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+  name                         = "${var.environment_name}-users-app-client-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
   user_pool_id                 = aws_cognito_user_pool.cognito_user_pool.id
   supported_identity_providers = ["COGNITO"]
   explicit_auth_flows          = ["ADMIN_NO_SRP_AUTH"]
@@ -50,7 +50,7 @@ resource "aws_cognito_user_pool_ui_customization" "cognito_ui_customization" {
 }
 
 resource "aws_cognito_user_pool" "cognito_token_pool" {
-  name = "${var.environment_name}-${var.service_name}-client-tokens-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+  name = "${var.environment_name}-client-tokens-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
 
   mfa_configuration = "OFF"
 


### PR DESCRIPTION
```
Terraform will perform the following actions:

  # module.service_module.aws_cognito_user_pool.cognito_token_pool must be replaced
-/+ resource "aws_cognito_user_pool" "cognito_token_pool" {
      ~ arn                        = "arn:aws:cognito-idp:us-east-1:941165240011:userpool/us-east-1_al7eThJ92" -> (known after apply)
      - auto_verified_attributes   = [] -> null
      ~ creation_date              = "2021-03-29T21:00:41Z" -> (known after apply)
      + email_verification_message = (known after apply)
      + email_verification_subject = (known after apply)
      ~ endpoint                   = "cognito-idp.us-east-1.amazonaws.com/us-east-1_al7eThJ92" -> (known after apply)
      ~ id                         = "us-east-1_al7eThJ92" -> (known after apply)
      ~ last_modified_date         = "2021-03-29T21:00:41Z" -> (known after apply)
      ~ name                       = "dev-authentication-service-client-tokens-use1" -> "dev-client-tokens-use1" # forces replacement
      + sms_verification_message   = (known after apply)
      - tags                       = {} -> null
        # (1 unchanged attribute hidden)


      ~ device_configuration {
          - challenge_required_on_new_device      = false -> null
            # (1 unchanged attribute hidden)
        }

      - email_configuration {
          - email_sending_account = "COGNITO_DEFAULT" -> null
        }

      + lambda_config {
          + create_auth_challenge          = (known after apply)
          + custom_message                 = (known after apply)
          + define_auth_challenge          = (known after apply)
          + post_authentication            = (known after apply)
          + post_confirmation              = (known after apply)
          + pre_authentication             = (known after apply)
          + pre_sign_up                    = (known after apply)
          + pre_token_generation           = (known after apply)
          + user_migration                 = (known after apply)
          + verify_auth_challenge_response = (known after apply)
        }

      ~ password_policy {
          - temporary_password_validity_days = 7 -> null
            # (5 unchanged attributes hidden)
        }

      + sms_configuration {
          + external_id    = (known after apply)
          + sns_caller_arn = (known after apply)
        }


      ~ verification_message_template {
          ~ default_email_option  = "CONFIRM_WITH_CODE" -> (known after apply)
          + email_message         = (known after apply)
          + email_message_by_link = (known after apply)
          + email_subject         = (known after apply)
          + email_subject_by_link = (known after apply)
          + sms_message           = (known after apply)
        }
        # (2 unchanged blocks hidden)
    }

  # module.service_module.aws_cognito_user_pool.cognito_user_pool must be replaced
-/+ resource "aws_cognito_user_pool" "cognito_user_pool" {
      ~ arn                        = "arn:aws:cognito-idp:us-east-1:941165240011:userpool/us-east-1_14hRN4cT4" -> (known after apply)
      ~ creation_date              = "2021-03-29T21:00:41Z" -> (known after apply)
      + email_verification_message = (known after apply)
      + email_verification_subject = (known after apply)
      ~ endpoint                   = "cognito-idp.us-east-1.amazonaws.com/us-east-1_14hRN4cT4" -> (known after apply)
      ~ id                         = "us-east-1_14hRN4cT4" -> (known after apply)
      ~ last_modified_date         = "2021-03-29T21:00:41Z" -> (known after apply)
      ~ name                       = "dev-authentication-service-users-use1" -> "dev-users-use1" # forces replacement
      + sms_verification_message   = (known after apply)
      - tags                       = {} -> null
        # (3 unchanged attributes hidden)



      ~ device_configuration {
          - challenge_required_on_new_device      = false -> null
            # (1 unchanged attribute hidden)
        }

      - email_configuration {
          - email_sending_account = "COGNITO_DEFAULT" -> null
        }

      + lambda_config {
          + create_auth_challenge          = (known after apply)
          + custom_message                 = (known after apply)
          + define_auth_challenge          = (known after apply)
          + post_authentication            = (known after apply)
          + post_confirmation              = (known after apply)
          + pre_authentication             = (known after apply)
          + pre_sign_up                    = (known after apply)
          + pre_token_generation           = (known after apply)
          + user_migration                 = (known after apply)
          + verify_auth_challenge_response = (known after apply)
        }

      ~ password_policy {
          ~ minimum_length                   = 8 -> (known after apply)
          ~ require_lowercase                = true -> (known after apply)
          ~ require_numbers                  = true -> (known after apply)
          ~ require_symbols                  = true -> (known after apply)
          ~ require_uppercase                = true -> (known after apply)
          ~ temporary_password_validity_days = 7 -> (known after apply)
        }

      + sms_configuration {
          + external_id    = (known after apply)
          + sns_caller_arn = (known after apply)
        }



      ~ verification_message_template {
          ~ default_email_option  = "CONFIRM_WITH_CODE" -> (known after apply)
          + email_message         = (known after apply)
          + email_message_by_link = (known after apply)
          + email_subject         = (known after apply)
          + email_subject_by_link = (known after apply)
          + sms_message           = (known after apply)
        }
        # (4 unchanged blocks hidden)
    }

  # module.service_module.aws_cognito_user_pool_client.cognito_token_pool_client must be replaced
-/+ resource "aws_cognito_user_pool_client" "cognito_token_pool_client" {
      - access_token_validity                = 0 -> null
      - allowed_oauth_flows                  = [] -> null
      - allowed_oauth_flows_user_pool_client = false -> null
      - allowed_oauth_scopes                 = [] -> null
      - callback_urls                        = [] -> null
      + client_secret                        = (sensitive value)
      ~ id                                   = "7o9c68bvrepcecbbkmn63mdmrp" -> (known after apply)
      - id_token_validity                    = 0 -> null
      - logout_urls                          = [] -> null
        name                                 = "dev-client-tokens-app-client-use1"
      + prevent_user_existence_errors        = (known after apply)
      - read_attributes                      = [] -> null
      ~ user_pool_id                         = "us-east-1_al7eThJ92" -> (known after apply) # forces replacement
      - write_attributes                     = [] -> null
        # (3 unchanged attributes hidden)
    }

  # module.service_module.aws_cognito_user_pool_client.cognito_user_pool_client must be replaced
-/+ resource "aws_cognito_user_pool_client" "cognito_user_pool_client" {
      - access_token_validity                = 0 -> null
      - allowed_oauth_flows                  = [] -> null
      - allowed_oauth_flows_user_pool_client = false -> null
      - allowed_oauth_scopes                 = [] -> null
      - callback_urls                        = [] -> null
      + client_secret                        = (sensitive value)
      ~ id                                   = "1m9hbu8grne2hmdt238avnb0l5" -> (known after apply)
      - id_token_validity                    = 0 -> null
      - logout_urls                          = [] -> null
      ~ name                                 = "dev-authentication-service-users-app-client-use1" -> "dev-users-app-client-use1"
      + prevent_user_existence_errors        = (known after apply)
      ~ user_pool_id                         = "us-east-1_14hRN4cT4" -> (known after apply) # forces replacement
        # (5 unchanged attributes hidden)
    }

  # module.service_module.aws_cognito_user_pool_domain.cognito_user_pool_domain must be replaced
-/+ resource "aws_cognito_user_pool_domain" "cognito_user_pool_domain" {
      ~ aws_account_id              = "941165240011" -> (known after apply)
      ~ cloudfront_distribution_arn = "d3oia8etllorh5.cloudfront.net" -> (known after apply)
      ~ domain                      = "dev-authentication-service-users-use1" -> "dev-users-use1" # forces replacement
      ~ id                          = "dev-authentication-service-users-use1" -> (known after apply)
      ~ s3_bucket                   = "aws-cognito-prod-iad-assets" -> (known after apply)
      ~ user_pool_id                = "us-east-1_14hRN4cT4" -> (known after apply) # forces replacement
      ~ version                     = "20210329210042" -> (known after apply)
    }

  # module.service_module.aws_cognito_user_pool_ui_customization.cognito_ui_customization will be updated in-place
  ~ resource "aws_cognito_user_pool_ui_customization" "cognito_ui_customization" {
      ~ client_id          = "1m9hbu8grne2hmdt238avnb0l5" -> (known after apply)
        id                 = "us-east-1_14hRN4cT4,1m9hbu8grne2hmdt238avnb0l5"
      ~ user_pool_id       = "us-east-1_14hRN4cT4" -> (known after apply)
        # (4 unchanged attributes hidden)
    }

Plan: 5 to add, 1 to change, 5 to destroy.

Changes to Outputs:
  ~ token_pool_arn       = "arn:aws:cognito-idp:us-east-1:941165240011:userpool/us-east-1_al7eThJ92" -> (known after apply)
  ~ token_pool_client_id = "7o9c68bvrepcecbbkmn63mdmrp" -> (known after apply)
  ~ token_pool_id        = "us-east-1_al7eThJ92" -> (known after apply)
  ~ user_pool_arn        = "arn:aws:cognito-idp:us-east-1:941165240011:userpool/us-east-1_14hRN4cT4" -> (known after apply)
  ~ user_pool_client_id  = "1m9hbu8grne2hmdt238avnb0l5" -> (known after apply)
  ~ user_pool_id         = "us-east-1_14hRN4cT4" -> (known after apply)

------------------------------------------------------------------------
```