### PR TITLE
Removing tracking of devices

### DIFF
--- a/terraform/cognito.tf
+++ b/terraform/cognito.tf
@@ -27,10 +27,6 @@ resource "aws_cognito_user_pool" "cognito_user_pool" {
     allow_admin_create_user_only = true
   }
 
-  device_configuration {
-    device_only_remembered_on_user_prompt = true
-  }
-
   software_token_mfa_configuration {
     enabled = true
   }
@@ -161,10 +157,6 @@ resource "aws_cognito_user_pool" "cognito_user_pool_2" {
     allow_admin_create_user_only = true
   }
 
-  device_configuration {
-    device_only_remembered_on_user_prompt = true
-  }
-
   software_token_mfa_configuration {
     enabled = true
   }
@@ -266,10 +258,6 @@ resource "aws_cognito_user_pool" "cognito_token_pool" {
 
   admin_create_user_config {
     allow_admin_create_user_only = true
-  }
-
-  device_configuration {
-    device_only_remembered_on_user_prompt = true
   }
 
   password_policy {


### PR DESCRIPTION
Removing tracking of devices in Cognito pools.
This makes refreshing tokens easier and we don't actually have any features tied to tracking devices such as limiting the number of devices per user that can access the platform